### PR TITLE
Remove accidentally copy-pasted duplicate event listener

### DIFF
--- a/src/legacy/directory-open.mjs
+++ b/src/legacy/directory-open.mjs
@@ -44,10 +44,6 @@ export default async (options = [{}]) => {
       options[0].legacySetup(_resolve, _reject, input);
 
     input.addEventListener('change', () => {
-      _resolve(input.multiple ? Array.from(input.files) : input.files[0]);
-    });
-
-    input.addEventListener('change', () => {
       let files = Array.from(input.files);
       if (!options[0].recursive) {
         files = files.filter((file) => {


### PR DESCRIPTION
I have just migrated your changes over and I encourage you to deprecate the fork. But just in case you keep it alive, this fix might save anyone using it from tripping over a mean issue.